### PR TITLE
FIX Ensure MFA login forms have a name which identifies it as multi factor

### DIFF
--- a/src/Forms/BootstrapMFALoginForm.php
+++ b/src/Forms/BootstrapMFALoginForm.php
@@ -27,4 +27,9 @@ class BootstrapMFALoginForm extends MemberLoginForm
 
         return $fields;
     }
+
+    public function getAuthenticatorName()
+    {
+        return _t(__CLASS__ . '.AuthenticatorName', 'E-mail & Password (with MFA)');
+    }
 }

--- a/tests/unit/BootstrapMFALoginFormTest.php
+++ b/tests/unit/BootstrapMFALoginFormTest.php
@@ -47,4 +47,14 @@ class BootstrapMFALoginFormTest extends SapphireTest
 
         $this->assertEquals(null, $fields->dataFieldByName('tokens'));
     }
+
+    public function testGetAuthenticatorName()
+    {
+        $loginForm = $this->getMockBuilder(BootstrapMFALoginForm::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $this->assertContains('with MFA', $loginForm->getAuthenticatorName());
+    }
 }


### PR DESCRIPTION
Wording can be adjusted. Since this is an abstract module, it doesn't seem sensible to put anything more than this in. At least now it is differentiated from the default authenticator's name (E-mail & Password).

Issue: https://github.com/elliot-sawyer/totp-authenticator/issues/12