### PR TITLE
FIX Remove unecessary pass by reference from function args

### DIFF
--- a/src/Interfaces/MFAAuthenticator.php
+++ b/src/Interfaces/MFAAuthenticator.php
@@ -28,7 +28,7 @@ interface MFAAuthenticator
      * @param ValidationResult $result
      * @return mixed
      */
-    public function verifyMFA($data, $request, $token, &$result);
+    public function verifyMFA($data, $request, $token, $result);
 
     /**
      * Required to find the token field for the authenticator

--- a/tests/mock/MockAuthenticator.php
+++ b/tests/mock/MockAuthenticator.php
@@ -48,7 +48,7 @@ class MockAuthenticator extends BootstrapMFAAuthenticator implements TestOnly, M
      * @param ValidationResult $result
      * @return mixed
      */
-    public function verifyMFA($data, $request, $token, &$result)
+    public function verifyMFA($data, $request, $token, $result)
     {
         if (!$result) {
             $result = ValidationResult::create();


### PR DESCRIPTION
Objects are always passed by reference. We don't need to specify the `&` here.