### PR TITLE
Use recipe-cms to fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   # Install composer dependencies
   - composer validate
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --no-update; fi
-  - composer require silverstripe/recipe-core "$RECIPE_VERSION" --no-update
+  - composer require silverstripe/recipe-cms "$RECIPE_VERSION" --no-update
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:


### PR DESCRIPTION
If you don't use recipe-cms, and you end up installing modules from it, then you may end up with versions that are newer and incompatible with previous versions of recipe-core (which are constrained). It is what it is, but this fixes the builds.